### PR TITLE
implement android keystore to prevent unwarranted access to private key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ app/project.properties
 app/build.xml
 app/local.properties
 bin/*
+local.properties
+.gradle/
+.idea/
+*.iml
+*/build/

--- a/cameraVApp/src/main/AndroidManifest.xml
+++ b/cameraVApp/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     android:versionName="0.2.4">
 
     <uses-sdk
-        android:minSdkVersion="16"
+        android:minSdkVersion="19"
         android:targetSdkVersion="19" />
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -22,7 +22,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.GET_TASKS" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
     <uses-permission android:name="android.permission.VIBRATE" />

--- a/informaCam/src/main/AndroidManifest.xml
+++ b/informaCam/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="16"
+        android:minSdkVersion="19"
         android:targetSdkVersion="19" />
 
 

--- a/informaCam/src/main/java/org/witness/informacam/crypto/KeyUtility.java
+++ b/informaCam/src/main/java/org/witness/informacam/crypto/KeyUtility.java
@@ -150,7 +150,7 @@ public class KeyUtility {
 	public static boolean initDevice() {
 
 		int progress = 1;
-		Bundle data = new Bundle();
+        Bundle data = new Bundle();
 		data.putInt(Codes.Extras.MESSAGE_CODE, Codes.Messages.UI.UPDATE);
 		data.putInt(Codes.Keys.UI.PROGRESS, progress);
 
@@ -302,7 +302,15 @@ public class KeyUtility {
         return new String(bytes, 0, bytes.length, "UTF-8");
     }
 
-    private static String wrapSecretAuthToken(String secretAuthToken) throws GeneralSecurityException, IOException {
+    public static boolean checkForLegacyAuthToken(String secretAuthToken) {
+        if(secretAuthToken.length() <= 44) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static String wrapSecretAuthToken(String secretAuthToken) throws GeneralSecurityException, IOException {
         // encrypt to Android Keystore first.
 
         final Calendar start = new GregorianCalendar();
@@ -349,9 +357,9 @@ public class KeyUtility {
 		data.putInt(Codes.Extras.MESSAGE_CODE, Codes.Messages.UI.UPDATE);
 		data.putInt(Codes.Keys.UI.PROGRESS, progress);
 
-		try {
+        try {
 
-			String secretAuthToken, keyStorePassword;
+            String secretAuthToken, keyStorePassword;
 
             progress += 10;
             data.putInt(Codes.Keys.UI.PROGRESS, progress);
@@ -445,7 +453,7 @@ public class KeyUtility {
 			ISecretKey secretKeyPackage = new ISecretKey();
 			secretKeyPackage.pgpKeyFingerprint = pgpKeyFingerprint;
 			secretKeyPackage.secretAuthToken = wrapSecretAuthToken(secretAuthToken);
-			secretKeyPackage.secretKey = Base64.encodeToString(secret.getEncoded(), Base64.DEFAULT);
+            secretKeyPackage.secretKey = Base64.encodeToString(secret.getEncoded(), Base64.DEFAULT);
 
 			progress += 10;
 			data.putInt(Codes.Keys.UI.PROGRESS, progress);

--- a/informaCam/src/main/java/org/witness/informacam/crypto/SignatureService.java
+++ b/informaCam/src/main/java/org/witness/informacam/crypto/SignatureService.java
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.Reader;
+import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 
@@ -30,23 +30,22 @@ import android.content.Context;
 import android.util.Log;
 
 public class SignatureService {
-	
+
 	private PGPSecretKey secretKey = null;
 	private PGPPrivateKey privateKey = null;
 	private PGPPublicKey publicKey = null;
 	private String authKey = null;
-	
+
 	private static String LOG = Crypto.LOG;
-	
-	public SignatureService (Context context)
-	{
-		
-	}
-	
-	
+
+	public SignatureService (Context context) {}
+
+
 	@SuppressWarnings({"deprecation" })
-	public void initKey(ISecretKey sk) throws PGPException {
-		authKey = sk.secretAuthToken;
+	public void initKey(ISecretKey sk) throws PGPException, GeneralSecurityException, IOException {
+		// decrypt secretAuthToken with Android Keystore first.
+		authKey = KeyUtility.unwrapSecretAuthToken(sk.secretAuthToken);
+
 		secretKey = KeyUtility.extractSecretKey(sk.secretKey.getBytes());
 		privateKey = secretKey.extractPrivateKey(authKey.toCharArray(), new BouncyCastleProvider());
 		publicKey = secretKey.getPublicKey();

--- a/informaCam/src/main/java/org/witness/informacam/utils/Constants.java
+++ b/informaCam/src/main/java/org/witness/informacam/utils/Constants.java
@@ -520,6 +520,7 @@ public class Constants {
 
 		public class ICredentials {
 			public final static String PASSWORD_BLOCK = "passwordBlock";
+			public final static String PASSWORD_ALIAS = "CameraV1_2";
 		}
 
 		public class IPendingConnections {


### PR DESCRIPTION
(https://github.com/harlo/CameraV/issues/3)

While access to the internal data is protected on non-rooted devices, a rooted device could potentially access the contents of the iocipher storage and abuse the private key.

Proposed fixes:
1. use android keystore to further protect access to private key's credentials, that way it can only be accessed in-app

We should further discuss properly using Android Keystore, especially in relation to rooted devices.
